### PR TITLE
USB TX fixes

### DIFF
--- a/main/usb_uart_bridge_main.c
+++ b/main/usb_uart_bridge_main.c
@@ -494,7 +494,7 @@ void app_main(void)
 
     ESP_ERROR_CHECK(tinyusb_driver_install(&tusb_cfg));
 
-    tinyusb_config_cdcacm_t amc_cfg = {
+    tinyusb_config_cdcacm_t acm_cfg = {
         .usb_dev = TINYUSB_USBDEV_0,
         .cdc_port = TINYUSB_CDC_ACM_0,
         .rx_unread_buf_sz = USB_RX_BUF_SIZE,
@@ -504,7 +504,7 @@ void app_main(void)
         .callback_line_coding_changed = &tinyusb_cdc_line_coding_changed_callback
     };
 
-    ESP_ERROR_CHECK(tusb_cdc_acm_init(&amc_cfg));
+    ESP_ERROR_CHECK(tusb_cdc_acm_init(&acm_cfg));
 
     TaskHandle_t usb_tx_handle = NULL;
     xTaskCreate(usb_tx_task, "usb_tx", 4096, NULL, 4, &usb_tx_handle);

--- a/main/usb_uart_bridge_main.c
+++ b/main/usb_uart_bridge_main.c
@@ -362,8 +362,9 @@ static void usb_tx_task(void *arg)
             size_t ret = tinyusb_cdcacm_write_queue(0, data, rx_data_size);
             ESP_LOGV(TAG, "usb tx data size = %d ret=%u", rx_data_size, ret);
             tud_cdc_n_write_flush(0);
-            //We wait for 10 times of the time it takes to send the data
-            uint32_t timeout_ms = 10 * (rx_data_size / 64 / 19 + 1);
+
+            // We wait for 10 times of the time it takes to send the data
+            uint32_t timeout_ms = 10 * (1000 * (uint32_t)rx_data_size / s_baud_rate_active);
             if (_wait_for_usb_tx_done(timeout_ms) != ESP_OK) {
                 xSemaphoreTake(s_usb_tx_requested, 0);
                 ESP_LOGD(TAG, "usb tx timeout");

--- a/main/usb_uart_bridge_main.c
+++ b/main/usb_uart_bridge_main.c
@@ -400,6 +400,7 @@ static void uart_writer_task(void *arg) {
     size_t rx_size;
 
     while (1) {
+        ESP_LOGD(TAG, "waiting for data to send to uart");
         uint8_t *rx_buf = (uint8_t *)xRingbufferReceiveUpTo(s_usb_rx_ringbuf, &rx_size, pdMS_TO_TICKS(portMAX_DELAY), sizeof(data_to_uart));
 
         if (!rx_buf) {
@@ -418,6 +419,8 @@ static void uart_writer_task(void *arg) {
             ESP_LOGD(TAG, "uart write lost (%d/%d)", xfer_size, rx_size);
         }
 
+        ESP_LOGD(TAG, "waiting for UART buffer to flush");
+        ESP_ERROR_CHECK(uart_wait_tx_done(BOARD_UART_PORT, pdMS_TO_TICKS(portMAX_DELAY)));
     }
 }
 


### PR DESCRIPTION
With the dependency upgrade in #8, tinyUSB now behaves a little differently for me and USB sends are chunked into 64 byte segments when using `tinyusb_cdcacm_write_queue`. `tud_cdc_tx_complete_cb` is called for every 64 byte chunk but we unblock the semaphore on the first block send. To work around this, I've rewritten `usb_tx_task` to be woken up on new received serial data via `uart_read_task` (as it currently works) but then enqueue and *flush* the whole chunk of data in one go before continuing to send the next chunk of UART data.

