### PR TITLE
Software ESP32 bootloader trigger

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -1,16 +1,5 @@
 menu "USB UART Bridge Example"
 
-    config UART_AUTO_DOWNLOAD
-        bool "Enable auto download, if enable please attach io0 and rst"
-        default n
-    config BOARD_AUTODLD_EN_PIN
-        int "Auto download EN(RST) pin"
-        default 3
-        depends on UART_AUTO_DOWNLOAD
-    config BOARD_AUTODLD_BOOT_PIN
-        int "Auto download BOOT pin"
-        default 26
-        depends on UART_AUTO_DOWNLOAD
     config BOARD_UART_TXD_PIN
         int "UART TXD pin"
         default 14

--- a/main/usb_uart_bridge_main.c
+++ b/main/usb_uart_bridge_main.c
@@ -28,11 +28,7 @@ static const char *TAG = "USB2UART";
 // serial port in this order. Some OSes reset the serial port to a default baudrate so
 // as long as these are opened in this order (but not necessarily sequentially), the
 // bootloader will be triggered.
-const uint32_t MAGIC_BOOTLOADER_TRIGGER_BAUDRATES[] = {
-    111111,
-    222222,
-    333333,
-};
+const uint32_t MAGIC_BOOTLOADER_TRIGGER_BAUDRATES[] = {150, 300, 600};
 const uint64_t MAGIC_BOOTLOADER_TRIGGER_TIMEOUT_MICROS = 5000000;
 
 #define BOARD_UART_PORT        UART_NUM_1


### PR DESCRIPTION
To allow entering the ESP32 bootloader from software, I propose using a sequence "magic" baudrates, in a specific order, within a set period of time. No application would ever use this and it allows us to signal the ESP32 side while avoiding messing with flow control signals or inspecting serial traffic.

It looks like macOS resets the serial port to `9600` and then `38400` after opening/closing the port so this sequence of baudrates needs to be sent within 5s to activate.

It's very simple to use and works reliably for me:

```python
import sys
import time
import serial as pyserial

print("Opening serial port with magic baudrate")

MAGIC_BOOTLOADER_SEQUENCE = [111111, 222222, 333333]

for index, baudrate in enumerate(MAGIC_BOOTLOADER_SEQUENCE, start=1):
    with pyserial.Serial(sys.argv[1], baudrate=baudrate):
        print(f"Opening with baudrate {baudrate} ({index} of {len(MAGIC_BOOTLOADER_SEQUENCE)})")
        time.sleep(1)

print("Waiting a second for the USB interface to appear")
time.sleep(3)
```

The software USB device uninitializes and is replaced with the standard ESP32 bootloader in a few seconds. This will allow for ESP32 firmware upgrades without requiring anything but standard serial port communication, making it usable over WebSerial.

CC @kbx81 