### PR TITLE
Update README.md with updated references

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The example using `ESP32-S3-OTG` board by default, the IO configuration is as fo
 ESP USB Bridge (USB to UART & JTAG bridge implementation for ESP-IDF by Espressif):
 * https://github.com/espressif/esp-usb-bridge
   * https://github.com/espressif/esp-usb-bridge#readme
+    * https://github.com/espressif/esp-dev-kits/blob/master/docs/en/esp32-s3-usb-bridge/user_guide.rst
 
 Wireless USB UART Bridge (ESP32-S3-USB-Bridge) example :
 * https://github.com/espressif/esp-dev-kits/tree/master/examples/esp32-s3-usb-bridge/examples/usb_wireless_bridge


### PR DESCRIPTION
Update README.md with updated references, which fixes https://github.com/NabuCasa/zwave-esp-bridge/issues/17

First of all, Espressif moved the wireless USB bridge code example from https://github.com/espressif/esp-dev-kits/tree/master/esp32-s3-usb-bridge/examples/usb_wireless_bridge to https://github.com/espressif/esp-dev-kits/tree/master/examples/esp32-s3-usb-bridge/examples/usb_wireless_bridge

Another relevant reference is this "new" dedicted repository for ESP USB Bridge from Espressif?

* https://github.com/espressif/esp-usb-bridge

  * https://github.com/espressif/esp-usb-bridge#readme

Anyway, the old URL to the wireless bridge example gives a 404 (file/page not found) error message if point to the master branch:

* https://github.com/espressif/esp-dev-kits/tree/master/esp32-s3-usb-bridge/examples/usb_wireless_bridge

<img width="1155" height="475" alt="image" src="https://github.com/user-attachments/assets/dfd9b86f-774c-4fbf-91df-0e354123e555" />
