### PR TITLE
fix: reset sequence for ZG23 bootloader

### DIFF
--- a/main/usb_uart_bridge_main.c
+++ b/main/usb_uart_bridge_main.c
@@ -190,12 +190,12 @@ static void tinyusb_cdc_rx_callback(int itf, cdcacm_event_t *event)
                     } else if (rx_buf[1] == 'z' || rx_buf[1] == 'Z') {
                         // Trigger ZG23 bootloader
                         ESP_LOGW(TAG, "Invoking ZG23 bootloader");
-                        gpio_set_level(BOARD_ZG23_BTL_PIN, false);
+                        gpio_set_level(BOARD_ZG23_BTL_PIN, true);
                         gpio_set_level(BOARD_ZG23_RESET_PIN, false);
-                        vTaskDelay(pdMS_TO_TICKS(50));
+                        vTaskDelay(pdMS_TO_TICKS(100));
                         gpio_set_level(BOARD_ZG23_BTL_PIN, false);
                         gpio_set_level(BOARD_ZG23_RESET_PIN, true);
-                        vTaskDelay(pdMS_TO_TICKS(50));
+                        vTaskDelay(pdMS_TO_TICKS(500));
                         gpio_set_level(BOARD_ZG23_BTL_PIN, true);
                     } else {
                         ESP_LOGW(TAG, "Unknown command: %c%c", rx_buf[0], rx_buf[1]);


### PR DESCRIPTION
I realized during testing that the ZG23 bootloader reset through the command mode resulted in some strange serial output, without actually entering the bootloader. Turns out the sequence was wrong. I'm not sure if the higher delays are necessary, but those are the ones I used to use and they work.